### PR TITLE
feat(matches): implement match service and controller

### DIFF
--- a/src/matches/dto/create-match.dto.ts
+++ b/src/matches/dto/create-match.dto.ts
@@ -1,0 +1,1 @@
+export class CreateMatchDto {}

--- a/src/matches/dto/update-match.dto.ts
+++ b/src/matches/dto/update-match.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateMatchDto } from './create-match.dto';
+
+export class UpdateMatchDto extends PartialType(CreateMatchDto) {}

--- a/src/matches/entities/match.entity.ts
+++ b/src/matches/entities/match.entity.ts
@@ -1,0 +1,27 @@
+import { Tournament } from 'src/tournaments/entities/tournament.entity';
+import { User } from 'src/users/entities/user.entity';
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from 'typeorm';
+
+@Entity('matches')
+export class Match {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @ManyToOne(() => User)
+    player1: User;
+
+    @ManyToOne(() => User)
+    player2: User;
+
+    @ManyToOne(() => Tournament, tournament => tournament.matches)
+    tournament: Tournament;
+
+    @Column({nullable: true})
+    scorePlayer1: number;
+
+    @Column({nullable: true})
+    scorePlayer2: number;
+
+    @Column({nullable: true})
+    result: 'Player1_WIN' | 'Player2_WIN' | 'DRAW' | null;
+}

--- a/src/matches/matches.controller.spec.ts
+++ b/src/matches/matches.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MatchesController } from './matches.controller';
+import { MatchesService } from './matches.service';
+
+describe('MatchesController', () => {
+  let controller: MatchesController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [MatchesController],
+      providers: [MatchesService],
+    }).compile();
+
+    controller = module.get<MatchesController>(MatchesController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/matches/matches.controller.ts
+++ b/src/matches/matches.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { MatchesService } from './matches.service';
+import { CreateMatchDto } from './dto/create-match.dto';
+import { UpdateMatchDto } from './dto/update-match.dto';
+
+@Controller('matches')
+export class MatchesController {
+  constructor(private readonly matchesService: MatchesService) { }
+
+  @Post(':matchId/result')
+  registerMatchResult(
+    @Param('matchId') matchId: number, @Body('player1Score') player1Score: number, @Body('player2Score') player2Score: number,) {
+    return this.matchesService.registerMatchResult(matchId, player1Score, player2Score);
+  }
+
+}

--- a/src/matches/matches.module.ts
+++ b/src/matches/matches.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { MatchesService } from './matches.service';
+import { MatchesController } from './matches.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Match } from './entities/match.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Match])],
+  controllers: [MatchesController],
+  providers: [MatchesService],
+})
+export class MatchesModule {}

--- a/src/matches/matches.service.spec.ts
+++ b/src/matches/matches.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MatchesService } from './matches.service';
+
+describe('MatchesService', () => {
+  let service: MatchesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [MatchesService],
+    }).compile();
+
+    service = module.get<MatchesService>(MatchesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/matches/matches.service.ts
+++ b/src/matches/matches.service.ts
@@ -1,0 +1,49 @@
+import {
+  BadRequestException,
+  Injectable,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Match } from './entities/match.entity';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class MatchesService {
+  constructor(
+    @InjectRepository(Match)
+    private readonly matchRepository: Repository<Match>,
+  ) { }
+
+  async registerMatchResult(
+    matchId: number,
+    player1Score: number,
+    player2Score: number,
+  ): Promise<any> {
+    try {
+      const match = await this.matchRepository.findOne({
+        where: { id: matchId },
+      });
+      if (!match) {
+        throw new BadRequestException(`Match with id ${matchId} not found.`);
+      }
+
+      match.scorePlayer1 = player1Score;
+      match.scorePlayer2 = player2Score;
+
+      if (player1Score > player2Score) {
+        match.result = 'Player1_WIN';
+      } else if (player1Score < player2Score) {
+        match.result = 'Player2_WIN';
+      } else {
+        match.result = 'DRAW';
+      }
+
+      await this.matchRepository.save(match);
+      return match;
+    } catch (error) {
+      throw new InternalServerErrorException(
+        'Failed registering match result. ' + error.message,
+      );
+    }
+  }
+}

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -1,5 +1,6 @@
 import { Role } from "src/common/enums/role.enum";
-import { Column, Entity, PrimaryGeneratedColumn } from "typeorm";
+import { Match } from "src/matches/entities/match.entity";
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from "typeorm";
 
 @Entity('users')
 export class User {
@@ -23,4 +24,10 @@ export class User {
 
     @Column({ type: 'enum', enum: Role, default: Role.Admin })
     role: Role;
+
+    @OneToMany(() => Match, match => match.player1)
+    matchesAsPlayer1: Match[];
+
+    @OneToMany(() => Match, match => match.player2)
+    matchesAsPlayer2: Match[];
 }


### PR DESCRIPTION
- Added MatchService to handle business logic for matches.
- Implemented findOne method in MatchService to retrieve a match by ID.
- Created MatchController to expose endpoints for match operations.
- Added error handling for match retrieval in MatchService.